### PR TITLE
Bugfix: Fixed `nginx-example` Ingress Namespace

### DIFF
--- a/argocd/k8s/nginx-example/ingress.yml
+++ b/argocd/k8s/nginx-example/ingress.yml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nginx-example-ingress
-  namespace: kube-system
+  namespace: nginx-example
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
 spec:


### PR DESCRIPTION
- Updated `nginx-example` ingress to be located in `nginx-example` namespace