### PR TITLE
Bugfix: Fixed namespace for Longhorn ingress

### DIFF
--- a/argocd/apps/applications/longhorn.yml
+++ b/argocd/apps/applications/longhorn.yml
@@ -27,7 +27,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: longhorn-frontend-ingress
-  namespace: argocd
+  namespace: longhorn-system
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
 spec:


### PR DESCRIPTION
- Fixed namespace for Longhorn ingress (from `argocd` to `longhorn-system`)